### PR TITLE
Printing only xpath that not matches

### DIFF
--- a/src/main/java/com/jcabi/matchers/AllOfThatPrintsOnlyWrongMatchers.java
+++ b/src/main/java/com/jcabi/matchers/AllOfThatPrintsOnlyWrongMatchers.java
@@ -31,16 +31,14 @@ package com.jcabi.matchers;
 
 import java.util.ArrayList;
 import java.util.List;
-
 import org.hamcrest.Description;
 import org.hamcrest.DiagnosingMatcher;
 import org.hamcrest.Matcher;
-import org.hamcrest.core.AllOf;
 
 /**
- * Matcher that test if all matchers matches, but print info 
- * about only that ones who failed.
- * 
+ * Matcher that test if all matchers matches, but print info about only that
+ * ones who failed.
+ *
  * Based in {@link AllOf}
  *
  * @author Jose V. Dal Pra Junior (jrdalpra@gmail.com)
@@ -49,31 +47,48 @@ import org.hamcrest.core.AllOf;
  */
 final class AllOfThatPrintsOnlyWrongMatchers<T> extends DiagnosingMatcher<T> {
 
-        private final Iterable<Matcher<? super T>> matchers;
-        private final List<Matcher<? super T>> wrong;
-        
-        
-        public AllOfThatPrintsOnlyWrongMatchers(final Iterable<Matcher<? super T>> matchers) {
-            super();
-            this.matchers = matchers;
-            this.wrong = new ArrayList<Matcher<? super T>>();
-        }
+    /**
+     * Default size for list of wrong matchers.
+     */
+    private static final int SIZE = 10;
 
-        public final void describeTo(final Description description) {
-            description.appendList("(", ",", ")", wrong);
-        }
-        
-        @Override
-        public final boolean matches(final Object o, final Description mismatch) {
-            for (Matcher<? super T> matcher : matchers) {
-                if (!matcher.matches(o)) {
-                  mismatch.appendDescriptionOf(matcher).appendText(" ");
-                  matcher.describeMismatch(o, mismatch);
-                  wrong.add(matcher);
-                  return false;
-                }
-            }
-            return true;
-        }
-        
+    /**
+     * Matchers that will be tested.
+     */
+    private final transient Iterable<Matcher<? super T>> matchers;
+
+    /**
+     * Matchers that does not matches.
+     */
+    private final transient List<Matcher<? super T>> wrong;
+    /**
+     * Construct that accept matchers to test.
+     * @param iterable Matchers that will be tested.
+     */
+    public AllOfThatPrintsOnlyWrongMatchers(
+            final Iterable<Matcher<? super T>> iterable) {
+        super();
+        this.matchers = iterable;
+        this.wrong = new ArrayList<Matcher<? super T>>(SIZE);
     }
+
+    @Override
+    public void describeTo(final Description description) {
+        description.appendList("(", ",", ")", this.wrong);
+    }
+
+    @Override
+    public boolean matches(final Object obj, final Description mismatch) {
+        boolean matches = true;
+        for (final Matcher<? super T> matcher : this.matchers) {
+            if (!matcher.matches(obj)) {
+                mismatch.appendDescriptionOf(matcher).appendText(" ");
+                matcher.describeMismatch(obj, mismatch);
+                this.wrong.add(matcher);
+                matches = false;
+            }
+        }
+        return matches;
+    }
+
+}

--- a/src/main/java/com/jcabi/matchers/AllOfThatPrintsOnlyWrongMatchers.java
+++ b/src/main/java/com/jcabi/matchers/AllOfThatPrintsOnlyWrongMatchers.java
@@ -29,6 +29,7 @@
  */
 package com.jcabi.matchers;
 
+import com.jcabi.aspects.Tv;
 import java.util.ArrayList;
 import java.util.List;
 import org.hamcrest.Description;
@@ -48,11 +49,6 @@ import org.hamcrest.Matcher;
 final class AllOfThatPrintsOnlyWrongMatchers<T> extends DiagnosingMatcher<T> {
 
     /**
-     * Default size for list of wrong matchers.
-     */
-    private static final int SIZE = 10;
-
-    /**
      * Matchers that will be tested.
      */
     private final transient Iterable<Matcher<? super T>> matchers;
@@ -69,7 +65,7 @@ final class AllOfThatPrintsOnlyWrongMatchers<T> extends DiagnosingMatcher<T> {
             final Iterable<Matcher<? super T>> iterable) {
         super();
         this.matchers = iterable;
-        this.wrong = new ArrayList<Matcher<? super T>>(SIZE);
+        this.wrong = new ArrayList<Matcher<? super T>>(Tv.THREE);
     }
 
     @Override

--- a/src/main/java/com/jcabi/matchers/AllOfThatPrintsOnlyWrongMatchers.java
+++ b/src/main/java/com/jcabi/matchers/AllOfThatPrintsOnlyWrongMatchers.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) 2011-2015, jcabi.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the jcabi.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.jcabi.matchers;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.hamcrest.Description;
+import org.hamcrest.DiagnosingMatcher;
+import org.hamcrest.Matcher;
+import org.hamcrest.core.AllOf;
+
+/**
+ * Matcher that test if all matchers matches, but print info 
+ * about only that ones who failed.
+ * 
+ * Based in {@link AllOf}
+ *
+ * @author Jose V. Dal Pra Junior (jrdalpra@gmail.com)
+ * @version $Id$
+ * @since 0.2.6
+ */
+final class AllOfThatPrintsOnlyWrongMatchers<T> extends DiagnosingMatcher<T> {
+
+        private final Iterable<Matcher<? super T>> matchers;
+        private final List<Matcher<? super T>> wrong;
+        
+        
+        public AllOfThatPrintsOnlyWrongMatchers(final Iterable<Matcher<? super T>> matchers) {
+            super();
+            this.matchers = matchers;
+            this.wrong = new ArrayList<Matcher<? super T>>();
+        }
+
+        public final void describeTo(final Description description) {
+            description.appendList("(", ",", ")", wrong);
+        }
+        
+        @Override
+        public final boolean matches(final Object o, final Description mismatch) {
+            for (Matcher<? super T> matcher : matchers) {
+                if (!matcher.matches(o)) {
+                  mismatch.appendDescriptionOf(matcher).appendText(" ");
+                  matcher.describeMismatch(o, mismatch);
+                  wrong.add(matcher);
+                  return false;
+                }
+            }
+            return true;
+        }
+        
+    }

--- a/src/main/java/com/jcabi/matchers/XhtmlMatchers.java
+++ b/src/main/java/com/jcabi/matchers/XhtmlMatchers.java
@@ -42,7 +42,6 @@ import javax.xml.transform.Source;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.hamcrest.Matcher;
-import org.hamcrest.Matchers;
 import org.w3c.dom.Node;
 
 /**
@@ -171,7 +170,7 @@ public final class XhtmlMatchers {
         for (final String xpath : xpaths) {
             list.add(XhtmlMatchers.<T>hasXPath(xpath));
         }
-        return Matchers.allOf(list);
+        return new AllOfThatPrintsOnlyWrongMatchers<T>(list);
     }
 
     /**

--- a/src/test/java/com/jcabi/matchers/XhtmlMatchersTest.java
+++ b/src/test/java/com/jcabi/matchers/XhtmlMatchersTest.java
@@ -242,7 +242,7 @@ public final class XhtmlMatchersTest {
      * @throws Exception
      */
     @Test
-    public void printsOnlyWrongXPaths() {
+    public void hasXPathsPrintsOnlyWrongXPaths() {
         try {
             MatcherAssert.assertThat(
                 "<b><file>some.txt</file><file>ghi.txt</file></b>",

--- a/src/test/java/com/jcabi/matchers/XhtmlMatchersTest.java
+++ b/src/test/java/com/jcabi/matchers/XhtmlMatchersTest.java
@@ -245,10 +245,11 @@ public final class XhtmlMatchersTest {
     public void hasXPathsPrintsOnlyWrongXPaths() {
         try {
             MatcherAssert.assertThat(
-                "<b><file>some.txt</file><file>ghi.txt</file></b>",
+                "<b><file>some.txt</file><file>gni.txt</file></b>",
                 XhtmlMatchers.hasXPaths(
                     "/b/file[.='some.txt']",
-                    "/b/file[.='ghx.txt']"
+                    "/b/file[.='gnx.txt']",
+                    "/b/file[.='gni.txt']"
                 )
             );
         } catch (final AssertionError error) {
@@ -257,10 +258,10 @@ public final class XhtmlMatchersTest {
                 Matchers.hasToString(
                     StringUtils.join(
                         "\nExpected: (an XML document ",
-                        "with XPath /b/file[.='ghx.txt'])\n",
+                        "with XPath /b/file[.='gnx.txt'])\n",
                         "     but: an XML document with XPath",
-                        " /b/file[.='ghx.txt'] was \"",
-                        "<b><file>some.txt</file><file>ghi.txt</file></b>\""
+                        " /b/file[.='gnx.txt'] was \"",
+                        "<b><file>some.txt</file><file>gni.txt</file></b>\""
                     )
                 )
             );

--- a/src/test/java/com/jcabi/matchers/XhtmlMatchersTest.java
+++ b/src/test/java/com/jcabi/matchers/XhtmlMatchersTest.java
@@ -237,6 +237,36 @@ public final class XhtmlMatchersTest {
         );
     }
 
+    /**
+     * This method should only prints wrong xpaths.
+     * @throws Exception
+     */
+    @Test
+    public void printsOnlyWrongXPaths() {
+        try {
+            MatcherAssert.assertThat(
+                "<b><file>some.txt</file><file>ghi.txt</file></b>",
+                XhtmlMatchers.hasXPaths(
+                    "/b/file[.='some.txt']",
+                    "/b/file[.='ghx.txt']"
+                )
+            );
+        } catch (final AssertionError error) {
+            MatcherAssert.assertThat(
+                error.getMessage(),
+                Matchers.hasToString(
+                    StringUtils.join(
+                        "\nExpected: (an XML document ",
+                        "with XPath /b/file[.='ghx.txt'])\n",
+                        "     but: an XML document with XPath",
+                        " /b/file[.='ghx.txt'] was \"",
+                        "<b><file>some.txt</file><file>ghi.txt</file></b>\""
+                    )
+                )
+            );
+        }
+    }
+
     @XmlType(name = "foo", namespace = XhtmlMatchersTest.Foo.NAMESPACE)
     @XmlAccessorType(XmlAccessType.NONE)
     public static final class Foo {


### PR DESCRIPTION
Solving issue #26 

- New matcher that check if a collection of matchers matches and print info only the ones that don't matches
- Changing the of "Matchers.allOf" for this new one
- Added a new test case to check if AssertionError has info only about the wrong xpaths