### PR TITLE
For #42: Remove obsolete gem options from .rultor.yml

### DIFF
--- a/.rultor.yml
+++ b/.rultor.yml
@@ -2,8 +2,8 @@ architect:
 - yegor256
 - dmarkov
 install:
-- sudo gem install pdd
-- sudo gem install est
+- sudo gem install pdd -v 0.20.5
+- sudo gem install est -v 0.3.4
 assets:
   secring.gpg: yegor256/home#assets/secring.gpg
   settings.xml: yegor256/home#assets/jcabi/settings.xml

--- a/.rultor.yml
+++ b/.rultor.yml
@@ -2,8 +2,8 @@ architect:
 - yegor256
 - dmarkov
 install:
-- sudo gem install --no-ri --no-rdoc pdd
-- sudo gem install --no-ri --no-rdoc est
+- sudo gem install pdd
+- sudo gem install est
 assets:
   secring.gpg: yegor256/home#assets/secring.gpg
   settings.xml: yegor256/home#assets/jcabi/settings.xml

--- a/src/test/java/com/jcabi/matchers/W3CMatchersTest.java
+++ b/src/test/java/com/jcabi/matchers/W3CMatchersTest.java
@@ -52,7 +52,7 @@ public final class W3CMatchersTest {
         MatcherAssert.assertThat(
             StringUtils.join(
                 "<!DOCTYPE html>",
-                "<html><head><meta charset='UTF-8'/>",
+                "<html lang='en'><head><meta charset='UTF-8'/>",
                 "<title>hey</title></head>",
                 "<body></body></html>"
             ),


### PR DESCRIPTION
- Remove options
- Use the same versions as for travis