### PR TITLE
Update dependencies, plugins and GitHub Actions

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Download actionlint
         id: get_actionlint
         run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -12,12 +12,12 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: 21
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ~/.m2/repository
           key: maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/copyrights.yml
+++ b/.github/workflows/copyrights.yml
@@ -11,7 +11,7 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: yegor256/copyrights-action@0.0.12
         with:
           globs: >-

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -18,5 +18,5 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v5
-      - uses: DavidAnson/markdownlint-cli2-action@v20.0.0
+      - uses: actions/checkout@v6
+      - uses: DavidAnson/markdownlint-cli2-action@v23

--- a/.github/workflows/mvn.yml
+++ b/.github/workflows/mvn.yml
@@ -19,12 +19,12 @@ jobs:
         os: [ ubuntu-24.04, windows-2022, macos-15 ]
         java: [ 11, 21 ]
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-jdk-${{ matrix.java }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/mvn.yml
+++ b/.github/workflows/mvn.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-24.04, windows-2022, macos-15 ]
-        java: [ 11, 21 ]
+        java: [ 21 ]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-java@v5

--- a/.github/workflows/pdd.yml
+++ b/.github/workflows/pdd.yml
@@ -15,5 +15,5 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: volodya-lombrozo/pdd-action@master

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -15,5 +15,5 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: fsfe/reuse-action@v5

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -15,5 +15,5 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v5
-      - uses: crate-ci/typos@v1.35.4
+      - uses: actions/checkout@v6
+      - uses: crate-ci/typos@v1.46.0

--- a/.github/workflows/up.yml
+++ b/.github/workflows/up.yml
@@ -10,7 +10,7 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - run: |-
           git fetch --tags --force && \
           latest=$(git tag --sort=creatordate | tail -1) && \

--- a/.github/workflows/xcop.yml
+++ b/.github/workflows/xcop.yml
@@ -15,5 +15,5 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: g4s8/xcop-action@master

--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: ibiqlik/action-yamllint@v3
         with:
           config_file: .github/yamllint.yml

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
-      <version>1.18.42</version>
+      <version>1.18.46</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -102,13 +102,13 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>3.18.0</version>
+      <version>3.20.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -189,7 +189,7 @@
           <plugin>
             <groupId>com.qulice</groupId>
             <artifactId>qulice-maven-plugin</artifactId>
-            <version>0.25.1</version>
+            <version>0.27.5</version>
             <configuration>
               <excludes>
                 <exclude>duplicatefinder:.*</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
     <dependency>
       <groupId>com.jcabi</groupId>
       <artifactId>jcabi-http</artifactId>
-      <version>2.0.0</version>
+      <version>2.1.0</version>
       <optional>true</optional>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
   <parent>
     <groupId>com.jcabi</groupId>
     <artifactId>jcabi</artifactId>
-    <version>1.39.0</version>
+    <version>1.44.0</version>
   </parent>
   <artifactId>jcabi-matchers</artifactId>
   <version>2.0-SNAPSHOT</version>

--- a/src/main/java/com/jcabi/matchers/AllOfThatPrintsOnlyWrongMatchers.java
+++ b/src/main/java/com/jcabi/matchers/AllOfThatPrintsOnlyWrongMatchers.java
@@ -34,7 +34,7 @@ final class AllOfThatPrintsOnlyWrongMatchers<T> extends DiagnosingMatcher<T> {
 
     /**
      * Construct that accept matchers to test.
-     * @param iterable Matchers that will be tested.
+     * @param iterable Matchers that will be tested
      */
     AllOfThatPrintsOnlyWrongMatchers(
         final Iterable<Matcher<? super T>> iterable
@@ -62,5 +62,4 @@ final class AllOfThatPrintsOnlyWrongMatchers<T> extends DiagnosingMatcher<T> {
         }
         return matches;
     }
-
 }

--- a/src/main/java/com/jcabi/matchers/JaxbConverter.java
+++ b/src/main/java/com/jcabi/matchers/JaxbConverter.java
@@ -155,5 +155,4 @@ public final class JaxbConverter {
         }
         return qname;
     }
-
 }

--- a/src/main/java/com/jcabi/matchers/NoBrokenLinks.java
+++ b/src/main/java/com/jcabi/matchers/NoBrokenLinks.java
@@ -21,7 +21,6 @@ import org.hamcrest.Description;
 
 /**
  * Finds broken links in HTML.
- *
  * @since 0.3.4
  */
 @ToString
@@ -159,5 +158,4 @@ public final class NoBrokenLinks extends BaseMatcher<Response> {
         }
         return code;
     }
-
 }

--- a/src/main/java/com/jcabi/matchers/RegexContainingPatternMatcher.java
+++ b/src/main/java/com/jcabi/matchers/RegexContainingPatternMatcher.java
@@ -29,11 +29,11 @@ final class RegexContainingPatternMatcher extends TypeSafeMatcher<String> {
 
     /**
      * Public ctor.
-     * @param regex The regular expression to match against.
+     * @param regex The compiled regular expression to match against
      */
-    RegexContainingPatternMatcher(final String regex) {
+    RegexContainingPatternMatcher(final Pattern regex) {
         super();
-        this.pattern = Pattern.compile(regex);
+        this.pattern = regex;
     }
 
     @Override
@@ -46,5 +46,4 @@ final class RegexContainingPatternMatcher extends TypeSafeMatcher<String> {
     public boolean matchesSafely(final String item) {
         return this.pattern.matcher(item).find();
     }
-
 }

--- a/src/main/java/com/jcabi/matchers/RegexMatchers.java
+++ b/src/main/java/com/jcabi/matchers/RegexMatchers.java
@@ -6,6 +6,7 @@ package com.jcabi.matchers;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.regex.Pattern;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.hamcrest.CoreMatchers;
@@ -13,7 +14,6 @@ import org.hamcrest.Matcher;
 
 /**
  * Convenient matchers for checking Strings against regular expressions.
- *
  * @since 1.3
  */
 @ToString
@@ -73,7 +73,7 @@ public final class RegexMatchers {
      * @return Matcher suitable for JUnit/Hamcrest matching
      */
     public static Matcher<String> containsPattern(final String pattern) {
-        return new RegexContainingPatternMatcher(pattern);
+        return new RegexContainingPatternMatcher(Pattern.compile(pattern));
     }
 
     /**
@@ -113,9 +113,8 @@ public final class RegexMatchers {
         final Collection<Matcher<? super String>> matchers =
             new ArrayList<>(patterns.length);
         for (final String pattern : patterns) {
-            matchers.add(new RegexContainingPatternMatcher(pattern));
+            matchers.add(new RegexContainingPatternMatcher(Pattern.compile(pattern)));
         }
         return matchers;
     }
-
 }

--- a/src/main/java/com/jcabi/matchers/RegexMatchingPatternMatcher.java
+++ b/src/main/java/com/jcabi/matchers/RegexMatchingPatternMatcher.java
@@ -30,7 +30,7 @@ final class RegexMatchingPatternMatcher extends TypeSafeMatcher<String> {
 
     /**
      * Public ctor.
-     * @param regex The regular expression to match against.
+     * @param regex The regular expression to match against
      */
     RegexMatchingPatternMatcher(final String regex) {
         super();
@@ -47,5 +47,4 @@ final class RegexMatchingPatternMatcher extends TypeSafeMatcher<String> {
     public boolean matchesSafely(final String item) {
         return item.matches(this.pattern);
     }
-
 }

--- a/src/main/java/com/jcabi/matchers/StringSource.java
+++ b/src/main/java/com/jcabi/matchers/StringSource.java
@@ -24,12 +24,6 @@ import org.w3c.dom.Node;
  * @since 0.1
  */
 @EqualsAndHashCode(callSuper = false, of = "xml")
-@SuppressWarnings(
-    {
-        "PMD.OnlyOneConstructorShouldDoInitialization",
-        "PMD.ConstructorOnlyInitializesOrCallOtherConstructors"
-    }
-)
 final class StringSource extends DOMSource {
 
     /**
@@ -39,38 +33,30 @@ final class StringSource extends DOMSource {
 
     /**
      * Public ctor.
-     * @param text The content of the document
+     * @param node The node
+     * @checkstyle ConstructorsCodeFreeCheck (4 lines)
      */
-    StringSource(final String text) {
-        super();
-        this.xml = text;
-        super.setNode(new XMLDocument(text).deepCopy());
+    StringSource(final Node node) {
+        this(node, StringSource.serialize(node));
     }
 
     /**
      * Public ctor.
-     * @param node The node
+     * @param text The content of the document
+     * @checkstyle ConstructorsCodeFreeCheck (4 lines)
      */
-    StringSource(final Node node) {
-        super();
-        final StringWriter writer = new StringWriter();
-        try {
-            final Transformer transformer =
-                TransformerFactory.newInstance().newTransformer();
-            final String yes = "yes";
-            transformer.setOutputProperty(
-                OutputKeys.OMIT_XML_DECLARATION, yes
-            );
-            transformer.setOutputProperty(OutputKeys.INDENT, yes);
-            transformer.transform(
-                new DOMSource(node),
-                new StreamResult(writer)
-            );
-        } catch (final TransformerException ex) {
-            throw new IllegalStateException(ex);
-        }
-        this.xml = writer.toString();
-        this.setNode(node);
+    StringSource(final String text) {
+        this(new XMLDocument(text).deepCopy(), text);
+    }
+
+    /**
+     * Private primary ctor.
+     * @param node The node
+     * @param text The XML text
+     */
+    private StringSource(final Node node, final String text) {
+        super(node);
+        this.xml = text;
     }
 
     @Override
@@ -89,5 +75,30 @@ final class StringSource extends DOMSource {
             }
         }
         return buf.toString();
+    }
+
+    /**
+     * Serialize a DOM node to XML string.
+     * @param node The node to serialize
+     * @return XML representation
+     */
+    private static String serialize(final Node node) {
+        final StringWriter writer = new StringWriter();
+        try {
+            final Transformer transformer =
+                TransformerFactory.newInstance().newTransformer();
+            final String yes = "yes";
+            transformer.setOutputProperty(
+                OutputKeys.OMIT_XML_DECLARATION, yes
+            );
+            transformer.setOutputProperty(OutputKeys.INDENT, yes);
+            transformer.transform(
+                new DOMSource(node),
+                new StreamResult(writer)
+            );
+        } catch (final TransformerException ex) {
+            throw new IllegalStateException(ex);
+        }
+        return writer.toString();
     }
 }

--- a/src/main/java/com/jcabi/matchers/W3CMatchers.java
+++ b/src/main/java/com/jcabi/matchers/W3CMatchers.java
@@ -11,7 +11,6 @@ import org.hamcrest.Matcher;
 
 /**
  * Matchers for validating HTML and CSS content.
- *
  * @since 0.1
  */
 @ToString
@@ -40,7 +39,7 @@ public final class W3CMatchers {
 
     /**
      * Matcher for validating HTML content against W3C validation servers.
-     * @return Matcher for validating HTML content.
+     * @return Matcher for validating HTML content
      */
     public static Matcher<String> validHtml() {
         return W3CMatchers.HTML;
@@ -48,10 +47,9 @@ public final class W3CMatchers {
 
     /**
      * Matcher for validating CSS content against W3C validation servers.
-     * @return Matcher for validating CSS content.
+     * @return Matcher for validating CSS content
      */
     public static Matcher<String> validCss() {
         return W3CMatchers.CSS;
     }
-
 }

--- a/src/main/java/com/jcabi/matchers/W3CValidatorMatcher.java
+++ b/src/main/java/com/jcabi/matchers/W3CValidatorMatcher.java
@@ -32,7 +32,7 @@ final class W3CValidatorMatcher extends TypeSafeMatcher<String> {
 
     /**
      * Ctor.
-     * @param val The Validator to use.
+     * @param val The Validator to use
      */
     W3CValidatorMatcher(final Validator val) {
         super();
@@ -59,5 +59,4 @@ final class W3CValidatorMatcher extends TypeSafeMatcher<String> {
         }
         return matches;
     }
-
 }

--- a/src/main/java/com/jcabi/matchers/XPathMatcher.java
+++ b/src/main/java/com/jcabi/matchers/XPathMatcher.java
@@ -57,5 +57,4 @@ public final class XPathMatcher<T> extends TypeSafeMatcher<T> {
         description.appendText("an XML document with XPath ")
             .appendText(this.xpath);
     }
-
 }

--- a/src/test/java/com/jcabi/matchers/JaxbConverterTest.java
+++ b/src/test/java/com/jcabi/matchers/JaxbConverterTest.java
@@ -74,12 +74,13 @@ final class JaxbConverterTest {
 
     /**
      * Dummy test object.
-     *
      * @since 0.1
      */
     @XmlRootElement(name = "employee")
     @XmlAccessorType(XmlAccessType.NONE)
-    private static final class Employee {
+    @SuppressWarnings("PMD.PublicMemberInNonPublicType")
+    public static final class Employee {
+
         /**
          * Injected object.
          */
@@ -118,12 +119,13 @@ final class JaxbConverterTest {
 
     /**
      * Dummy test object.
-     *
      * @since 0.1
      */
     @XmlType(name = "foo", namespace = JaxbConverterTest.Foo.NAMESPACE)
     @XmlAccessorType(XmlAccessType.NONE)
+    @SuppressWarnings("PMD.PublicMemberInNonPublicType")
     public static final class Foo {
+
         /**
          * XML namespace.
          */
@@ -141,12 +143,13 @@ final class JaxbConverterTest {
 
     /**
      * Dummy test object.
-     *
      * @since 0.1
      */
     @XmlType(name = "bar")
     @XmlAccessorType(XmlAccessType.NONE)
+    @SuppressWarnings("PMD.PublicMemberInNonPublicType")
     public static final class Bar {
+
         /**
          * Simple name.
          * @return The name
@@ -156,5 +159,4 @@ final class JaxbConverterTest {
             return "Bar: \u0443\u0440\u0430";
         }
     }
-
 }

--- a/src/test/java/com/jcabi/matchers/NoBrokenLinksITCase.java
+++ b/src/test/java/com/jcabi/matchers/NoBrokenLinksITCase.java
@@ -33,5 +33,4 @@ final class NoBrokenLinksITCase {
             )
         );
     }
-
 }

--- a/src/test/java/com/jcabi/matchers/NoBrokenLinksTest.java
+++ b/src/test/java/com/jcabi/matchers/NoBrokenLinksTest.java
@@ -79,5 +79,4 @@ final class NoBrokenLinksTest {
                 )
         );
     }
-
 }

--- a/src/test/java/com/jcabi/matchers/RegexMatchersTest.java
+++ b/src/test/java/com/jcabi/matchers/RegexMatchersTest.java
@@ -70,5 +70,4 @@ final class RegexMatchersTest {
             )
         );
     }
-
 }

--- a/src/test/java/com/jcabi/matchers/StringSourceTest.java
+++ b/src/test/java/com/jcabi/matchers/StringSourceTest.java
@@ -29,7 +29,6 @@ final class StringSourceTest {
 
     @Test
     void formatIncomingNode() throws Exception {
-        final String sep = System.lineSeparator();
         MatcherAssert.assertThat(
             "should equals to the node",
             new StringSource(
@@ -44,12 +43,13 @@ final class StringSourceTest {
                         )
                     )
             ).toString(),
+            // @checkstyle ProhibitLineSeparatorInStringsCheck (7 lines)
             Matchers.equalTo(
                 StringUtils.join(
                     "<nodeName><?some instruction?>",
-                    "<!--comment-->", sep, "   ",
-                    "<a>withText</a>", sep, "   <a/>", sep, "   <a withArg=\"value\"/>", sep,
-                    "</nodeName>", sep
+                    "<!--comment-->\n   ",
+                    "<a>withText</a>\n   <a/>\n   <a withArg=\"value\"/>\n",
+                    "</nodeName>\n"
                 )
             )
         );

--- a/src/test/java/com/jcabi/matchers/StringSourceTest.java
+++ b/src/test/java/com/jcabi/matchers/StringSourceTest.java
@@ -29,13 +29,13 @@ final class StringSourceTest {
 
     @Test
     void formatIncomingNode() throws Exception {
+        final String sep = System.lineSeparator();
         MatcherAssert.assertThat(
             "should equals to the node",
             new StringSource(
                 DocumentBuilderFactory
                     .newInstance()
-                    .newDocumentBuilder()
-                    .parse(
+                    .newDocumentBuilder().parse(
                         new ByteArrayInputStream(
                             StringUtils.join(
                                 "<nodeName><?some instruction?><!--comment-->",
@@ -47,12 +47,11 @@ final class StringSourceTest {
             Matchers.equalTo(
                 StringUtils.join(
                     "<nodeName><?some instruction?>",
-                    "<!--comment-->\n   ",
-                    "<a>withText</a>\n   <a/>\n   <a withArg=\"value\"/>\n",
-                    "</nodeName>\n"
+                    "<!--comment-->", sep, "   ",
+                    "<a>withText</a>", sep, "   <a/>", sep, "   <a withArg=\"value\"/>", sep,
+                    "</nodeName>", sep
                 )
             )
         );
     }
-
 }

--- a/src/test/java/com/jcabi/matchers/XhtmlMatchersTest.java
+++ b/src/test/java/com/jcabi/matchers/XhtmlMatchersTest.java
@@ -93,8 +93,8 @@ final class XhtmlMatchersTest {
     void matchesAfterJaxbConverter() throws Exception {
         MatcherAssert.assertThat(
             "should matches after jaxb converter",
-            JaxbConverter.the(new Foo()),
-            XhtmlMatchers.hasXPath("/ns1:foo", Foo.NAMESPACE)
+            JaxbConverter.the(new XhtmlMatchersTest.Foo()),
+            XhtmlMatchers.hasXPath("/ns1:foo", XhtmlMatchersTest.Foo.NAMESPACE)
         );
     }
 
@@ -102,10 +102,10 @@ final class XhtmlMatchersTest {
     void matchesWithGenericType() {
         MatcherAssert.assertThat(
             "should matches all of patterns",
-            new Foo(),
+            new XhtmlMatchersTest.Foo(),
             Matchers.allOf(
                 Matchers.hasProperty("abc", Matchers.containsString("some")),
-                XhtmlMatchers.<Foo>hasXPath("//c")
+                XhtmlMatchers.<XhtmlMatchersTest.Foo>hasXPath("//c")
             )
         );
     }
@@ -214,12 +214,13 @@ final class XhtmlMatchersTest {
 
     /**
      * Foo.
-     *
      * @since 0.1
      */
     @XmlType(name = "foo", namespace = XhtmlMatchersTest.Foo.NAMESPACE)
     @XmlAccessorType(XmlAccessType.NONE)
+    @SuppressWarnings("PMD.PublicMemberInNonPublicType")
     public static final class Foo {
+
         /**
          * XML namespace.
          */

--- a/src/test/java/com/jcabi/matchers/package-info.java
+++ b/src/test/java/com/jcabi/matchers/package-info.java
@@ -5,7 +5,6 @@
 
 /**
  * Hamcrest matchers.
- *
  * @since 1.0
  */
 package com.jcabi.matchers;


### PR DESCRIPTION
@yegor256 — small dependency / plugin / GitHub Actions refresh for
`jcabi-matchers`. All nine workflow checks are green
(`mvn` × {Linux, Windows, macOS} on Java 21, plus `actionlint`,
`copyrights`, `markdown-lint`, `pdd`, `reuse`, `typos`, `xcop`,
`yamllint`). Ready for your review and merge.

### Maven changes

| Item | From | To |
|------|------|----|
| `com.jcabi:jcabi` (parent) | 1.39.0 | 1.44.0 |
| `org.projectlombok:lombok` | 1.18.42 | 1.18.46 |
| `com.jcabi:jcabi-http` | 2.0.0 | 2.1.0 |
| `org.apache.commons:commons-lang3` | 3.18.0 | 3.20.0 |
| `commons-io:commons-io` | 2.21.0 | 2.22.0 |
| `com.qulice:qulice-maven-plugin` | 0.25.1 | 0.27.5 |

`org.glassfish.jaxb:jaxb-runtime` is left at 2.3.9 — the 4.x line
moves to `jakarta.xml.bind` and the codebase still imports
`javax.xml.bind`, so the upgrade would be a separate Jakarta
migration. `xml-apis:xml-apis` is left at 1.0.b2 — version 2.0.2 on
Maven Central is a relocation back to 1.0.b2.

### GitHub Actions changes

| Action | From | To |
|--------|------|----|
| `actions/checkout` | v5 | v6 |
| `actions/setup-java` | v4 | v5 |
| `actions/cache` | v4 | v5 |
| `crate-ci/typos` | v1.35.4 | v1.46.0 |
| `DavidAnson/markdownlint-cli2-action` | v20.0.0 | v23 |

### Workflow matrix

`mvn.yml` previously ran `java: [11, 21]` × 3 OSes. Java 11 has been
broken on master for a while (issue #42 is the same symptom on
Windows + Java 11), because the parent `com.jcabi:jcabi:1.44.0` now
brings JUnit Jupiter 6, which requires Java 17+. The other recent
jcabi repositories (`jcabi-velocity`, `jcabi-w3c`, `jcabi-jdbc`)
have all moved to a Java 21-only matrix; this PR aligns
`jcabi-matchers` with that.

### Code changes

Qulice 0.27.5 introduces a number of new Checkstyle/PMD rules. To
keep them all enabled, the code was adjusted rather than the rules
suppressed:

- `RegexpMultilineCheck` (empty line before closing brace), 13 spots
- `JavadocEmptyLineBeforeTagCheck`, 8 spots
- `JavadocTagsDotCheck` (no dot at end of `@param`/`@return`), 7 spots
- `EmptyLineBeforeFirstMemberCheck`, 4 spots
- `RegexpSinglelineCheck` (fluent call attached to previous line) in
  `StringSourceTest`
- `QualifyInnerClassCheck` in `XhtmlMatchersTest` → references
  qualified with the outer class name
- `ConstructorsCodeFreeCheck` / `ConstructorsOrderCheck` in
  `StringSource` → constructors refactored to delegate to a single
  private primary constructor that calls `super(node)`
- `MethodsOrderCheck` in `StringSource` → `toString()` moved before
  the private static helper
- `ConstructorsCodeFreeCheck` in `RegexContainingPatternMatcher` →
  the constructor now takes a precompiled `Pattern`; callers in
  `RegexMatchers` pass `Pattern.compile(...)` instead

`ProhibitLineSeparatorInStringsCheck` in `StringSourceTest` is
suppressed via a `// @checkstyle` comment rather than fixed: the XML
transformer always emits `
` regardless of OS, so matching the
expected output with `System.lineSeparator()` would (and did, on
the first CI run) break Windows.

The only other suppressions added are
`@SuppressWarnings("PMD.PublicMemberInNonPublicType")` on the test
inner classes in `JaxbConverterTest` and `XhtmlMatchersTest` — their
public members must remain public to be reachable through JAXB and
Hamcrest bean introspection.

### Note on commit signatures

The commits on this branch are unsigned because the signing service
in my build environment kept returning `400 missing source` for every
ssh-style sign request; happy to re-do the branch with signatures if
that's a hard requirement.