### PR TITLE
Migrate to Jakarta XML Binding (JAXB 4) and clean up dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,25 +114,25 @@
     <dependency>
       <groupId>xml-apis</groupId>
       <artifactId>xml-apis</artifactId>
-      <version>2.0.2</version>
+      <version>1.0.b2</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>javax.xml.bind</groupId>
-      <artifactId>jaxb-api</artifactId>
-      <version>2.4.0-b180830.0359</version>
+      <groupId>jakarta.xml.bind</groupId>
+      <artifactId>jakarta.xml.bind-api</artifactId>
+      <version>4.0.5</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jaxb</groupId>
       <artifactId>jaxb-runtime</artifactId>
-      <version>2.3.9</version>
+      <version>4.0.7</version>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>javax.ws.rs</groupId>
-      <artifactId>jsr311-api</artifactId>
-      <version>1.1.1</version>
+      <groupId>jakarta.ws.rs</groupId>
+      <artifactId>jakarta.ws.rs-api</artifactId>
+      <version>4.0.0</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -145,12 +145,6 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-reload4j</artifactId>
       <version>2.0.17</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-      <version>1.2.17</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/java/com/jcabi/matchers/JaxbConverter.java
+++ b/src/main/java/com/jcabi/matchers/JaxbConverter.java
@@ -4,14 +4,14 @@
  */
 package com.jcabi.matchers;
 
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBElement;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.JAXBIntrospector;
+import jakarta.xml.bind.Marshaller;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlType;
 import java.io.StringWriter;
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBElement;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.JAXBIntrospector;
-import javax.xml.bind.Marshaller;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlType;
 import javax.xml.namespace.QName;
 import javax.xml.transform.Source;
 import lombok.EqualsAndHashCode;
@@ -23,10 +23,10 @@ import lombok.ToString;
  * <p>The object has to be annotated with JAXB annotations
  * in order to be convertible. Let's consider an example JAXB-annotated class:
  *
- * <pre> import javax.xml.bind.annotation.XmlAccessType;
- * import javax.xml.bind.annotation.XmlAccessorType;
- * import javax.xml.bind.annotation.XmlElement;
- * import javax.xml.bind.annotation.XmlRootElement;
+ * <pre> import jakarta.xml.bind.annotation.XmlAccessType;
+ * import jakarta.xml.bind.annotation.XmlAccessorType;
+ * import jakarta.xml.bind.annotation.XmlElement;
+ * import jakarta.xml.bind.annotation.XmlRootElement;
  * &#64;XmlRootElement(name = "employee")
  * &#64;XmlAccessorType(XmlAccessType.NONE)
  * public class Employee {

--- a/src/main/resources/com/jcabi/matchers/jaxb.properties
+++ b/src/main/resources/com/jcabi/matchers/jaxb.properties
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
 # SPDX-License-Identifier: MIT
 
-# JAXB 2.0 reference implementation from com.sun.xml.bind:jaxb-impl:2.2.*
-javax.xml.bind.context.factory=com.sun.xml.bind.v2.ContextFactory
+# Jakarta XML Binding (JAXB) 4.x reference implementation
+jakarta.xml.bind.context.factory=org.glassfish.jaxb.runtime.v2.JAXBContextFactory

--- a/src/test/java/com/jcabi/matchers/JaxbConverterTest.java
+++ b/src/test/java/com/jcabi/matchers/JaxbConverterTest.java
@@ -4,11 +4,11 @@
  */
 package com.jcabi.matchers;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlType;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/jcabi/matchers/XhtmlMatchersTest.java
+++ b/src/test/java/com/jcabi/matchers/XhtmlMatchersTest.java
@@ -4,12 +4,12 @@
  */
 package com.jcabi.matchers;
 
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlType;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlType;
 import javax.xml.parsers.DocumentBuilderFactory;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;


### PR DESCRIPTION
@yegor256 this PR upgrades a few stale dependencies that I noticed while looking at the repo, and finishes the move from `javax.*` to `jakarta.*` for the JAXB and JAX-RS APIs (the long-standing `2.0-SNAPSHOT` makes it a natural place to take the breaking step). Build (`mvn clean install -Pqulice`) is green locally and on all three matrix OSes in CI.

## What changed

**JAXB / JAX-RS migration to Jakarta**
- `javax.xml.bind:jaxb-api 2.4.0-b180830.0359` (a beta from 2018) → `jakarta.xml.bind:jakarta.xml.bind-api 4.0.5`
- `org.glassfish.jaxb:jaxb-runtime 2.3.9` → `4.0.7` (latest stable; the 2.x line was at its terminal version, only the Jakarta 4.x line is still maintained)
- `javax.ws.rs:jsr311-api 1.1.1` (from 2010) → `jakarta.ws.rs:jakarta.ws.rs-api 4.0.0`
- `JaxbConverter`, `JaxbConverterTest`, `XhtmlMatchersTest` updated to import `jakarta.xml.bind.*`
- `src/main/resources/com/jcabi/matchers/jaxb.properties` updated to the Jakarta property name (`jakarta.xml.bind.context.factory`) and the JAXB-RI 4.x factory class

**Pre-existing cleanups**
- `xml-apis:xml-apis 2.0.2` → `1.0.b2`. The `2.0.2` artifact on Maven Central is just a `<distributionManagement><relocation/>` pointer back to `1.0.b2` (Renovate had been bouncing the version up and back, see commits `0313526` and the open `renovate/xml-apis-xml-apis-replacement` branch). Pinning the real version stops the churn.
- Dropped the explicit `log4j:log4j 1.2.17` test dependency. It was redundant: the `jcabi` parent pom already declares it in `dependencyManagement`, and at runtime the test classpath uses `ch.qos.reload4j:reload4j` (a maintained drop-in for log4j 1.2 with the known CVEs fixed), pulled in transitively via `org.slf4j:slf4j-reload4j`.

## Notes for review

- `JaxbConverter#the(Object, Class<?>...)` declares `throws jakarta.xml.bind.JAXBException` instead of `javax.xml.bind.JAXBException` — a binary-incompatible signature change for any caller that catches the exception, hence appropriate for the `2.0` major bump already in `pom.xml`.
- The other items flagged by `versions:display-dependency-updates` (`junit-jupiter 6.1.0-RC1`, `slf4j-reload4j 2.1.0-alpha1`) are pre-release and were skipped intentionally.
- The two `W3CMatchers` tests and `NoBrokenLinksTest#passesWithoutBrokenLinks` hit external services (`validator.w3.org`, `jigsaw.w3.org`, `teamed.io`) and are flaky in restricted networks; they pass on the GitHub-hosted runners in this run.

## Test plan
- `mvn clean install -Pqulice` — green locally and on `ubuntu-24.04`, `macos-15`, `windows-2022` (Java 21).
- All 11 CI checks (mvn × 3 OS, qulice, actionlint, reuse, typos, markdown-lint, copyrights, yamllint, xcop, pdd) passing on this branch.