### PR TITLE
Fix #34: strip default xmlns so unprefixed XPath matches

### DIFF
--- a/src/main/java/com/jcabi/matchers/XPathMatcher.java
+++ b/src/main/java/com/jcabi/matchers/XPathMatcher.java
@@ -5,11 +5,19 @@
 package com.jcabi.matchers;
 
 import com.jcabi.xml.XMLDocument;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+import java.util.Scanner;
+import java.util.regex.Pattern;
 import javax.xml.namespace.NamespaceContext;
+import javax.xml.transform.Source;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeMatcher;
+import org.w3c.dom.Node;
 
 /**
  * Matcher of XPath against a plain string.
@@ -22,6 +30,22 @@ import org.hamcrest.TypeSafeMatcher;
 @ToString
 @EqualsAndHashCode(callSuper = false, of = "xpath")
 public final class XPathMatcher<T> extends TypeSafeMatcher<T> {
+
+    /**
+     * Default-namespace declaration ({@code xmlns="..."}) pattern, but not
+     * a prefixed declaration like {@code xmlns:foo="..."}.
+     */
+    private static final Pattern DEFAULT_NS = Pattern.compile(
+        "\\s+xmlns\\s*=\\s*(\"[^\"]*\"|'[^']*')"
+    );
+
+    /**
+     * Detects a prefixed name in an XPath query (e.g. {@code ns1:foo}),
+     * while ignoring the {@code ::} XPath axis separator.
+     */
+    private static final Pattern PREFIXED = Pattern.compile(
+        "[A-Za-z_][A-Za-z0-9_.-]*:[A-Za-z_]"
+    );
 
     /**
      * The XPath to use.
@@ -46,7 +70,7 @@ public final class XPathMatcher<T> extends TypeSafeMatcher<T> {
 
     @Override
     public boolean matchesSafely(final T input) {
-        return !new XMLDocument(XhtmlMatchers.xhtml(input))
+        return !new XMLDocument(this.source(input))
             .merge(this.context)
             .nodes(this.xpath)
             .isEmpty();
@@ -56,5 +80,70 @@ public final class XPathMatcher<T> extends TypeSafeMatcher<T> {
     public void describeTo(final Description description) {
         description.appendText("an XML document with XPath ")
             .appendText(this.xpath);
+    }
+
+    /**
+     * Build the XML source for the input. When the XPath uses no namespace
+     * prefix, default-namespace declarations ({@code xmlns="..."}) are
+     * stripped from text-based inputs so that elements declared in a
+     * default namespace can be matched without requiring a prefix
+     * (see issue #34). Prefixed XPath queries and {@link Source}/{@link Node}
+     * inputs are passed through unchanged.
+     * @param input The input value
+     * @return XML source ready for XPath evaluation
+     */
+    private Source source(final T input) {
+        final Source result;
+        if (XPathMatcher.PREFIXED.matcher(this.xpath).find()
+            || input instanceof Source
+            || input instanceof Node) {
+            result = XhtmlMatchers.xhtml(input);
+        } else {
+            result = new StringSource(
+                XPathMatcher.DEFAULT_NS.matcher(XPathMatcher.asText(input))
+                    .replaceAll("")
+            );
+        }
+        return result;
+    }
+
+    /**
+     * Read the input as text, mirroring {@link XhtmlMatchers#xhtml(Object)}
+     * for non-{@link Source}/{@link Node} inputs.
+     * @param input The input value
+     * @return Text representation of the input
+     */
+    private static String asText(final Object input) {
+        final String text;
+        if (input instanceof InputStream) {
+            text = XPathMatcher.read(
+                new InputStreamReader(
+                    (InputStream) input,
+                    StandardCharsets.UTF_8
+                )
+            );
+        } else if (input instanceof Reader) {
+            text = XPathMatcher.read((Reader) input);
+        } else {
+            text = input.toString();
+        }
+        return text;
+    }
+
+    /**
+     * Read the entire content of a {@link Reader} as a string.
+     * @param reader The reader to read
+     * @return Reader content
+     */
+    private static String read(final Reader reader) {
+        final String result;
+        try (Scanner scanner = new Scanner(reader).useDelimiter("\\A")) {
+            if (scanner.hasNext()) {
+                result = scanner.next();
+            } else {
+                result = "";
+            }
+        }
+        return result;
     }
 }

--- a/src/test/java/com/jcabi/matchers/XhtmlMatchersTest.java
+++ b/src/test/java/com/jcabi/matchers/XhtmlMatchersTest.java
@@ -45,6 +45,66 @@ final class XhtmlMatchersTest {
     }
 
     @Test
+    void matchesWithoutPrefixWhenDefaultNamespace() {
+        MatcherAssert.assertThat(
+            "should match unprefixed XPath against element in default namespace",
+            "<a xmlns='foo'><b/></a>",
+            XhtmlMatchers.hasXPath("/a/b")
+        );
+    }
+
+    @Test
+    void matchesWithoutPrefixForXhtmlDefaultNamespace() {
+        MatcherAssert.assertThat(
+            "should match unprefixed XPath against XHTML in default namespace",
+            StringUtils.join(
+                "<html xmlns='http://www.w3.org/1999/xhtml'>",
+                "<body><p>hello</p></body></html>"
+            ),
+            XhtmlMatchers.hasXPath("/html/body/p[.='hello']")
+        );
+    }
+
+    @Test
+    void matchesWithoutPrefixForXhtmlInputStream() {
+        MatcherAssert.assertThat(
+            "should match unprefixed XPath when input is an InputStream",
+            IOUtils.toInputStream(
+                "<root xmlns='foo'><child>x</child></root>",
+                StandardCharsets.UTF_8
+            ),
+            XhtmlMatchers.hasXPath("/root/child[.='x']")
+        );
+    }
+
+    @Test
+    void matchesWithoutPrefixForXhtmlReader() {
+        MatcherAssert.assertThat(
+            "should match unprefixed XPath when input is a Reader",
+            new InputStreamReader(
+                IOUtils.toInputStream(
+                    "<root xmlns='bar'><child>y</child></root>",
+                    StandardCharsets.UTF_8
+                ),
+                StandardCharsets.UTF_8
+            ),
+            XhtmlMatchers.hasXPath("/root/child[.='y']")
+        );
+    }
+
+    @Test
+    void prefixedXPathStillMatchesDefaultNamespace() {
+        MatcherAssert.assertThat(
+            "should let prefixed XPath match elements in a default namespace",
+            "<messages xmlns='http://n.validator.nu/messages/'><info/></messages>",
+            XhtmlMatchers.hasXPath(
+                "//ns1:messages/ns1:info",
+                "http://n.validator.nu/messages/"
+            )
+        );
+    }
+
+    @Test
     void matchesPlainStringWithNamespace() {
         MatcherAssert.assertThat(
             "should has xpath",


### PR DESCRIPTION
@yegor256 fixes #34.

## What changed

When the XPath query passed to `XhtmlMatchers.hasXPath(...)` (or `XPathMatcher`) does **not** use any namespace prefix, default-namespace declarations of the form `xmlns="..."` are now stripped from text-based input (`String`/`Reader`/`InputStream`/`toString()`) before parsing, so XPath without a prefix can match elements declared in a default namespace. The change lives entirely in `XPathMatcher`; `XhtmlMatchers.xhtml(...)` is unchanged.

## Why it lives in `XPathMatcher`

My first attempt did the stripping inside `XhtmlMatchers.xhtml(...)`, which broke prefixed XPaths against default-namespaced XML — notably `jcabi-http`'s `XmlResponse.assertXPath(...)`, which calls `XhtmlMatchers.hasXPath("//ns:foo", ...)` against responses that carry `xmlns="..."` (the W3C tests in this very project exercise that path). Moving the conditional into `XPathMatcher` keeps the behaviour for prefixed XPath identical to before, so downstream callers keep working.

## Decision rule

In `XPathMatcher.matchesSafely`:

- If the XPath contains a prefixed name (`prefix:name`, ignoring the `::` axis separator), or the input is a `Source`/`Node`, behaviour is unchanged — the input goes through `XhtmlMatchers.xhtml(input)` as before.
- Otherwise, the input is read as text, the regex `\s+xmlns\s*=\s*("[^"]*"|'[^']*')` strips any default-namespace declarations, and the result is parsed. Prefixed declarations like `xmlns:foo="..."` are left alone.

## Tests

Five new `XhtmlMatchersTest` cases pin down the new behaviour:

- `matchesWithoutPrefixWhenDefaultNamespace` — `<a xmlns='foo'><b/></a>` matches `/a/b`.
- `matchesWithoutPrefixForXhtmlDefaultNamespace` — full XHTML with `xmlns='http://www.w3.org/1999/xhtml'` matches `/html/body/p[.='hello']`.
- `matchesWithoutPrefixForXhtmlInputStream` and `matchesWithoutPrefixForXhtmlReader` — same for `InputStream`/`Reader` inputs.
- `prefixedXPathStillMatchesDefaultNamespace` — regression guard: `<messages xmlns='http://n.validator.nu/messages/'>...</messages>` still matches `//ns1:messages/ns1:info` with the namespace passed in (mirrors how `jcabi-http` consumes `XhtmlMatchers`).

All 11 CI checks are green (Linux/macOS/Windows JDK 21 + actionlint, copyrights, markdown-lint, pdd, reuse, typos, xcop, yamllint).

Ready for review.